### PR TITLE
feat(candidatura): cria metodos http

### DIFF
--- a/src/main/java/com/example/temosvagas/contexts/relatorio/tarefas
+++ b/src/main/java/com/example/temosvagas/contexts/relatorio/tarefas
@@ -11,78 +11,7 @@
         return ResponseEntity.ok(candidatos);
     }
 
-    INSERIR EM OUTRA FEATURE
-        @PostMapping("/{id}/aplicar")
-        public ResponseEntity<?> aplicarVaga(@PathVariable Long id, @RequestParam Long idCandidato) {
-            var vagaOpt = vagaRepository.findById(id);
-            var candidatoOpt = candidatoRepository.findById(idCandidato);
 
-            if (vagaOpt.isEmpty() || candidatoOpt.isEmpty()) {
-                return ResponseEntity.notFound().build();
-            }
-
-            var vaga = vagaOpt.get();
-            var candidato = candidatoOpt.get();
-
-            //impede inscrição após o prazo
-            if (vaga.getDataLimite().isBefore(LocalDate.now())) {
-                return ResponseEntity.badRequest().body("Prazo para aplicação encerrado.");
-            }
-
-            //impede inscrição duplicada
-            if (vaga.getCandidatos().contains(candidato)) {
-                return ResponseEntity.badRequest().body("Candidato já inscrito nesta vaga.");
-            }
-
-            //testes de consistência com base no tipo da vaga
-            switch (vaga.getTipo()) {
-                case ESTAGIO -> {
-                    if (candidato.getCursandoGraduacao() == null || !candidato.getCursandoGraduacao()) {
-                        return ResponseEntity.badRequest().body("Esta vaga é para estágio. Apenas candidatos cursando graduação podem se inscrever.");
-                    }
-                }
-                case TRAINEE -> {
-                    if (candidato.getAnoConclusao() == null) {
-                        return ResponseEntity.badRequest().body("Esta vaga é para trainee. Apenas candidatos com curso superior concluído podem se inscrever.");
-                    }
-                }
-                //vagas CARGO não precisam de validação extra no momento
-            }
-
-            vaga.getCandidatos().add(candidato);
-            vagaRepository.save(vaga);
-
-            return ResponseEntity.ok("Inscrição realizada com sucesso.");
-        }
-
-
-    INSERIR EM OUTRA FEATURE
-       @PutMapping("/{id}/prorrogar")
-        //Empresa prorroga data antes do encerramento
-        public ResponseEntity<?> prorrogarDataLimite(@PathVariable Long id, @RequestParam LocalDate novaDataLimite) {
-            var vagaOpt = vagaRepository.findById(id);
-            if (vagaOpt.isEmpty()) {
-                return ResponseEntity.notFound().build();
-            }
-
-            var vaga = vagaOpt.get();
-
-            //Impede prorrogar se o prazo atual já expirou
-            if (vaga.getDataLimite().isBefore(LocalDate.now())) {
-                return ResponseEntity.badRequest().body("Não é possível prorrogar uma vaga cujo prazo já expirou.");
-            }
-
-            //Impede definir uma nova data no passado
-            if (novaDataLimite.isBefore(LocalDate.now())) {
-                return ResponseEntity.badRequest().body("A nova data limite deve ser uma data futura.");
-            }
-
-            vaga.setDataLimite(novaDataLimite);
-            vagaRepository.save(vaga);
-
-            return ResponseEntity.ok("Data limite prorrogada com sucesso.");
-        }
-    }
 
 
 

--- a/src/main/java/com/example/temosvagas/controllers/CandidaturaController.java
+++ b/src/main/java/com/example/temosvagas/controllers/CandidaturaController.java
@@ -1,0 +1,70 @@
+package com.example.temosvagas.controllers;
+
+import com.example.temosvagas.dtos.CandidaturaRequestDTO;
+import com.example.temosvagas.dtos.CandidaturaResponseDTO;
+import com.example.temosvagas.services.CandidaturaService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/candidaturas")
+public class CandidaturaController {
+
+    @Autowired
+    private CandidaturaService candidaturaService;
+
+    /**
+     * Lista todas as candidaturas registradas.
+     *
+     * @return ResponseEntity contendo lista de CandidaturaResponseDTO e status 200 (OK)
+     */
+    @GetMapping
+    public ResponseEntity<List<CandidaturaResponseDTO>> listarTodas() {
+        List<CandidaturaResponseDTO> dtos = candidaturaService.listarTodas();
+        return ResponseEntity.ok(dtos);
+    }
+
+    /**
+     * Busca uma candidatura pelo seu ID.
+     *
+     * @param id o identificador da candidatura
+     * @return ResponseEntity contendo os dados da candidatura e status 200 (OK)
+     * @throws org.springframework.web.server.ResponseStatusException com status 404 se não encontrada
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<CandidaturaResponseDTO> buscarPorId(@PathVariable Long id) {
+        CandidaturaResponseDTO dto = candidaturaService.buscarPorId(id);
+        return ResponseEntity.ok(dto);
+    }
+
+    /**
+     * Cria uma nova candidatura -> Aplica para Vaga
+     *
+     * @param requestDTO os dados da candidatura (candidatoId e vagaId)
+     * @return ResponseEntity com os dados da candidatura criada e status 201 (Created)
+     * @throws org.springframework.web.server.ResponseStatusException se o candidato ou vaga não existirem
+     */
+    @PostMapping
+    public ResponseEntity<CandidaturaResponseDTO> criar(@RequestBody @Valid CandidaturaRequestDTO requestDTO) {
+        CandidaturaResponseDTO responseDTO = candidaturaService.criarCandidatura(requestDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+    }
+
+    /**
+     * Deleta uma candidatura pelo ID.
+     *
+     * @param id identificador da candidatura
+     * @return ResponseEntity com status 204 (No Content) se a exclusão for bem-sucedida
+     * @throws org.springframework.web.server.ResponseStatusException com status 404 se a candidatura não for encontrada
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+        candidaturaService.deletarCandidatura(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/temosvagas/controllers/VagaController.java
+++ b/src/main/java/com/example/temosvagas/controllers/VagaController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -82,6 +83,21 @@ public class VagaController {
             @RequestBody @Valid VagaRequestDTO requestDTO) {
         VagaResponseDTO responseDTO = vagaService.atualizarVaga(id, requestDTO);
         return ResponseEntity.ok(responseDTO);
+    }
+
+    /**
+     * Prorroga a data limite de uma vaga, desde que a vaga ainda esteja em aberto.
+     *
+     * @param id o ID da vaga a ser prorrogada
+     * @param novaDataLimite nova data limite desejada
+     * @return mensagem de sucesso ou erro
+     */
+    @PutMapping("/{id}/prorrogar")
+    public ResponseEntity<String> prorrogarDataLimite(
+            @PathVariable Long id,
+            @RequestParam LocalDate novaDataLimite) {
+        vagaService.prorrogarDataLimite(id, novaDataLimite);
+        return ResponseEntity.ok("Data limite prorrogada com sucesso.");
     }
 
     /**

--- a/src/main/java/com/example/temosvagas/dtos/CandidaturaRequestDTO.java
+++ b/src/main/java/com/example/temosvagas/dtos/CandidaturaRequestDTO.java
@@ -1,0 +1,22 @@
+package com.example.temosvagas.dtos;
+
+import com.example.temosvagas.entities.Candidato;
+import com.example.temosvagas.entities.Candidatura;
+import com.example.temosvagas.entities.Vaga;
+import jakarta.validation.constraints.NotNull;
+
+public record CandidaturaRequestDTO(
+        @NotNull(message = "O ID do candidato é obrigatório")
+        Long candidatoId,
+
+        @NotNull(message = "O ID da vaga é obrigatório")
+        Long vagaId
+) {
+    public Candidatura toEntity(Candidato candidato, Vaga vaga) {
+        Candidatura candidatura = new Candidatura();
+        candidatura.setCandidato(candidato);
+        candidatura.setVaga(vaga);
+        candidatura.setStatus("PENDENTE"); // status inicial padrão
+        return candidatura;
+    }
+}

--- a/src/main/java/com/example/temosvagas/dtos/CandidaturaResponseDTO.java
+++ b/src/main/java/com/example/temosvagas/dtos/CandidaturaResponseDTO.java
@@ -1,0 +1,27 @@
+package com.example.temosvagas.dtos;
+
+import com.example.temosvagas.entities.Candidatura;
+
+import java.time.LocalDate;
+
+public record CandidaturaResponseDTO(
+        Long id,
+        LocalDate dataAplicacao,
+        String status,
+        Long candidatoId,
+        String nomeCandidato,
+        Long vagaId,
+        String tituloVaga
+) {
+    public static CandidaturaResponseDTO toDTO(Candidatura candidatura) {
+        return new CandidaturaResponseDTO(
+                candidatura.getId(),
+                candidatura.getDataAplicacao(),
+                candidatura.getStatus(),
+                candidatura.getCandidato().getId(),
+                candidatura.getCandidato().getNome(),
+                candidatura.getVaga().getId(),
+                candidatura.getVaga().getTitulo()
+        );
+    }
+}

--- a/src/main/java/com/example/temosvagas/entities/Candidatura.java
+++ b/src/main/java/com/example/temosvagas/entities/Candidatura.java
@@ -1,10 +1,16 @@
 package com.example.temosvagas.entities;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Candidatura {
 
     @Id

--- a/src/main/java/com/example/temosvagas/repositories/CandidaturaRepository.java
+++ b/src/main/java/com/example/temosvagas/repositories/CandidaturaRepository.java
@@ -1,0 +1,7 @@
+package com.example.temosvagas.repositories;
+
+import com.example.temosvagas.entities.Candidatura;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CandidaturaRepository extends JpaRepository<Candidatura, Long> {
+}

--- a/src/main/java/com/example/temosvagas/services/CandidaturaService.java
+++ b/src/main/java/com/example/temosvagas/services/CandidaturaService.java
@@ -1,0 +1,114 @@
+package com.example.temosvagas.services;
+
+import com.example.temosvagas.dtos.CandidaturaRequestDTO;
+import com.example.temosvagas.dtos.CandidaturaResponseDTO;
+import com.example.temosvagas.entities.Candidato;
+import com.example.temosvagas.entities.Candidatura;
+import com.example.temosvagas.entities.Vaga;
+import com.example.temosvagas.repositories.CandidatoRepository;
+import com.example.temosvagas.repositories.CandidaturaRepository;
+import com.example.temosvagas.repositories.VagaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class CandidaturaService {
+
+    @Autowired
+    private CandidaturaRepository candidaturaRepository;
+
+    @Autowired
+    private CandidatoRepository candidatoRepository;
+
+    @Autowired
+    private VagaRepository vagaRepository;
+
+    public List<CandidaturaResponseDTO> listarTodas() {
+        List<Candidatura> candidaturas = candidaturaRepository.findAll();
+        return candidaturas.stream()
+                .map(CandidaturaResponseDTO::toDTO)
+                .toList();
+    }
+
+    public CandidaturaResponseDTO buscarPorId(Long id) {
+        Candidatura candidatura = candidaturaRepository.findById(id).orElseThrow(() ->
+                new ResponseStatusException(HttpStatus.NOT_FOUND, "Candidatura não encontrada"));
+
+        return CandidaturaResponseDTO.toDTO(candidatura);
+    }
+
+    /**
+     * Realiza a candidatura de um candidato a uma vaga, aplicando todas as regras de negócio necessárias.
+     * <p>
+     * Regras aplicadas:
+     * <ul>
+     *     <li>Valida existência do candidato e da vaga</li>
+     *     <li>Impede inscrição após a data limite da vaga</li>
+     *     <li>Impede múltiplas inscrições do mesmo candidato na mesma vaga</li>
+     *     <li>Validações específicas por tipo de vaga:
+     *         <ul>
+     *             <li><b>ESTÁGIO</b>: apenas candidatos cursando graduação</li>
+     *             <li><b>TRAINEE</b>: apenas candidatos com curso superior concluído</li>
+     *             <li><b>CARGO</b>: sem validações adicionais</li>
+     *         </ul>
+     *     </li>
+     * </ul>
+     *
+     * @param dto DTO contendo os IDs do candidato e da vaga
+     * @return CandidaturaResponseDTO com os dados da candidatura criada
+     *
+     * @throws org.springframework.web.server.ResponseStatusException com status 404 se o candidato ou vaga não forem encontrados
+     * @throws org.springframework.web.server.ResponseStatusException com status 400 para qualquer violação das regras de negócio
+     */
+
+    public CandidaturaResponseDTO criarCandidatura(CandidaturaRequestDTO dto) {
+        Candidato candidato = candidatoRepository.findById(dto.candidatoId()).orElseThrow(() ->
+                new ResponseStatusException(HttpStatus.NOT_FOUND, "Candidato não encontrado"));
+
+        Vaga vaga = vagaRepository.findById(dto.vagaId()).orElseThrow(() ->
+                new ResponseStatusException(HttpStatus.NOT_FOUND, "Vaga não encontrada"));
+
+        if (vaga.getDataLimite().isBefore(LocalDate.now())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Prazo para aplicação encerrado.");
+        }
+
+        boolean jaInscrito = vaga.getCandidaturas().stream()
+                .anyMatch(c -> c.getCandidato().getId().equals(candidato.getId()));
+
+        if (jaInscrito) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Candidato já inscrito nesta vaga.");
+        }
+
+        switch (vaga.getTipo()) {
+            case ESTAGIO -> {
+                if (Boolean.FALSE.equals(candidato.getCursandoGraduacao())) {
+                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Esta vaga é para estágio. Apenas candidatos cursando graduação podem se inscrever.");
+                }
+            }
+            case TRAINEE -> {
+                if (candidato.getAnoConclusao() == null) {
+                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Esta vaga é para trainee. Apenas candidatos com curso superior concluído podem se inscrever.");
+                }
+            }
+            case CARGO -> {
+                // Nenhuma regra adicional
+            }
+        }
+
+        Candidatura candidatura = dto.toEntity(candidato, vaga);
+        Candidatura salva = candidaturaRepository.save(candidatura);
+        return CandidaturaResponseDTO.toDTO(salva);
+    }
+
+    public void deletarCandidatura(Long id) {
+        Candidatura candidatura = candidaturaRepository.findById(id).orElseThrow(() ->
+                new ResponseStatusException(HttpStatus.NOT_FOUND, "Candidatura não encontrada"));
+
+        candidaturaRepository.delete(candidatura);
+    }
+}

--- a/src/main/java/com/example/temosvagas/services/VagaService.java
+++ b/src/main/java/com/example/temosvagas/services/VagaService.java
@@ -81,6 +81,23 @@ public class VagaService {
         return VagaResponseDTO.toDTO(atualizada);
     }
 
+    public void prorrogarDataLimite(Long id, LocalDate novaDataLimite) {
+        Vaga vaga = vagaRepository.findById(id).orElseThrow(() ->
+                new ResponseStatusException(HttpStatus.NOT_FOUND, "Vaga não encontrada"));
+
+        if (vaga.getDataLimite().isBefore(LocalDate.now())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Não é possível prorrogar uma vaga cujo prazo já expirou.");
+        }
+
+        if (novaDataLimite.isBefore(LocalDate.now())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "A nova data limite deve ser uma data futura.");
+        }
+
+        vaga.setDataLimite(novaDataLimite);
+        vagaRepository.save(vaga);
+    }
+
+
     public void deletarVaga(Long id) {
         Vaga vaga = vagaRepository.findById(id).orElseThrow(() ->
                 new ResponseStatusException(HttpStatus.NOT_FOUND, "Vaga não encontrada"));


### PR DESCRIPTION
## ✨ Implementa módulo de Candidatura e prorrogação de Vaga com regras de negócio

### 📌 Descrição

Este PR adiciona as funcionalidades de candidatura a vagas e prorrogação de prazo de vagas, com validações de negócio implementadas de forma consistente na service, mantendo os controllers limpos.

---

### 🧩 Funcionalidades incluídas

#### ✅ Candidatura (módulo completo)

- Cadastro de nova candidatura com validações:
  - Impede candidatura após data limite da vaga
  - Impede duplicidade (mesmo candidato na mesma vaga)
  - Aplica regras conforme o tipo da vaga:
    - Estágio: exige `cursandoGraduacao = true`
    - Trainee: exige `anoConclusao != null`
- Listagem de todas as candidaturas
- Busca de candidatura por ID
- Exclusão de candidatura
- Conversão de DTOs com `toEntity()` e `toDTO()`

#### ✅ Prorrogação de vaga

- Endpoint `PUT /vagas/{id}/prorrogar` com regras:
  - Só permite prorrogação se a vaga ainda estiver em aberto
  - Nova data precisa ser no futuro
- Regras implementadas diretamente na camada de serviço (`VagaService`)

---

### 📂 Organização

- DTOs:
  - `CandidaturaRequestDTO`, `CandidaturaResponseDTO`
- Controllers:
  - `CandidaturaController`, `VagaController` (método de prorrogação)
- Services:
  - `CandidaturaService`, `VagaService` (com método `prorrogarDataLimite`)
- Regras centralizadas na service para manter controllers limpos

---

### ✅ Checklist

- [x] DTOs de candidatura com `toEntity` e `toDTO`
- [x] Service de candidatura com todas as regras de negócio
- [x] Controller REST com endpoints CRUD e retorno adequado
- [x] Endpoint de prorrogação com validações específicas
- [x] JavaDocs explicando cada endpoint e regra aplicada
