### PR TITLE
Funcionalidade/upload arquivo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.12.700</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>

--- a/src/main/java/com/example/temosvagas/config/AWSConfig.java
+++ b/src/main/java/com/example/temosvagas/config/AWSConfig.java
@@ -1,0 +1,24 @@
+package com.example.temosvagas.config;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AWSConfig {
+
+    @Value("${aws.region}")
+    private String awsRegion;
+
+    @Bean
+    public AmazonS3 createS3Instance() {
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new DefaultAWSCredentialsProviderChain())
+                .withRegion(awsRegion)
+                .build();
+    }
+}

--- a/src/main/java/com/example/temosvagas/contexts/carregaArquivo/CarregaArquivoController.java
+++ b/src/main/java/com/example/temosvagas/contexts/carregaArquivo/CarregaArquivoController.java
@@ -1,0 +1,31 @@
+package com.example.temosvagas.contexts.carregaArquivo;
+
+import com.example.temosvagas.dtos.CandidatoResponseDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/candidatos/arquivoCV")
+public class CarregaArquivoController {
+
+    @Autowired
+    private CarregaArquivoService carregaArquivoService;
+
+    /**
+     * Atualiza os dados de um do curriculo de um candidato existente com base no ID informado.
+     *
+     * @param id o identificador único do candidato a ser atualizado (vindo da URL)
+     * @param arquivo os dados do candidato enviados no corpo da requisição
+     * @return ResponseEntity com os dados atualizados do candidato e status 200 (OK)
+     */
+    @PutMapping(consumes = "multipart/form-data")
+    public ResponseEntity<CandidatoResponseDTO> atualizarArquivoCurriculo(
+            @RequestParam(value = "id") Long id,
+            @RequestParam(value = "arquivo") MultipartFile arquivo) {
+        CarregaArquivoRequestDTO requestDTO = new CarregaArquivoRequestDTO(arquivo);
+        CandidatoResponseDTO responseDTO = carregaArquivoService.atualizaArquivoCurriculo(id, requestDTO);
+        return ResponseEntity.ok(responseDTO);
+    }
+}

--- a/src/main/java/com/example/temosvagas/contexts/carregaArquivo/CarregaArquivoController.java
+++ b/src/main/java/com/example/temosvagas/contexts/carregaArquivo/CarregaArquivoController.java
@@ -14,11 +14,12 @@ public class CarregaArquivoController {
     private CarregaArquivoService carregaArquivoService;
 
     /**
-     * Atualiza os dados de um do curriculo de um candidato existente com base no ID informado.
+     * Atualiza o currículo de um candidato existente com base no ID do candidato.
+     * O novo arquivo enviado substitui o currículo anterior, sendo armazenado em um bucket S3.
      *
-     * @param id o identificador único do candidato a ser atualizado (vindo da URL)
-     * @param arquivo os dados do candidato enviados no corpo da requisição
-     * @return ResponseEntity com os dados atualizados do candidato e status 200 (OK)
+     * @param id o identificador único do candidato cujo currículo será atualizado (enviado como parâmetro de requisição)
+     * @param arquivo o novo arquivo de currículo enviado como multipart/form-data
+     * @return ResponseEntity contendo os dados atualizados do candidato e status HTTP 200 (OK)
      */
     @PutMapping(consumes = "multipart/form-data")
     public ResponseEntity<CandidatoResponseDTO> atualizarArquivoCurriculo(

--- a/src/main/java/com/example/temosvagas/contexts/carregaArquivo/CarregaArquivoRequestDTO.java
+++ b/src/main/java/com/example/temosvagas/contexts/carregaArquivo/CarregaArquivoRequestDTO.java
@@ -1,0 +1,6 @@
+package com.example.temosvagas.contexts.carregaArquivo;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record CarregaArquivoRequestDTO(MultipartFile arquivo) {
+}

--- a/src/main/java/com/example/temosvagas/contexts/carregaArquivo/CarregaArquivoService.java
+++ b/src/main/java/com/example/temosvagas/contexts/carregaArquivo/CarregaArquivoService.java
@@ -1,0 +1,70 @@
+package com.example.temosvagas.contexts.carregaArquivo;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.example.temosvagas.dtos.CandidatoResponseDTO;
+import com.example.temosvagas.entities.Candidato;
+import com.example.temosvagas.repositories.CandidatoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Random;
+
+@Service
+public class CarregaArquivoService {
+
+    @Autowired
+    private CandidatoRepository candidatoRepository;
+
+    @Autowired
+    private AmazonS3 s3Client;
+
+    @Value("${aws.bucket.name}")
+    private String awsBucketName;
+
+
+    public CandidatoResponseDTO atualizaArquivoCurriculo(Long id, CarregaArquivoRequestDTO dto) {
+        String arquivoUrl = null;
+
+        Candidato candidato = candidatoRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Candidato não encontrado"));
+
+        if (dto.arquivo() != null) {
+            arquivoUrl = this.carregaArquivo(dto.arquivo());
+            candidato.setArquivo(arquivoUrl);
+        }
+
+        Candidato candidatoSalvo = this.candidatoRepository.save(candidato);
+
+        return CandidatoResponseDTO.toDTO(candidatoSalvo);
+    }
+
+    private String carregaArquivo(MultipartFile arquivo) {
+        Random random = new Random();
+        String nomeArquivo = random + arquivo.getOriginalFilename();
+        try {
+            File arq = this.converteMultipartToFile(arquivo);
+            s3Client.putObject(awsBucketName, nomeArquivo, arq);
+            arq.delete();
+            return s3Client.getUrl(awsBucketName, nomeArquivo).toString();
+        } catch (Exception ex) {
+            System.out.println("Erro ao carregar arquivo: " + ex.getMessage());
+            return null;
+        }
+    }
+
+    private File converteMultipartToFile(MultipartFile arquivo) throws IOException {
+        File convFile = new File(Objects.requireNonNull(arquivo.getOriginalFilename()));
+        FileOutputStream fos = new FileOutputStream(convFile);
+        fos.write(arquivo.getBytes());
+        fos.close();
+        return convFile;
+    }
+}

--- a/src/main/java/com/example/temosvagas/controllers/CandidatoController.java
+++ b/src/main/java/com/example/temosvagas/controllers/CandidatoController.java
@@ -72,21 +72,6 @@ public class CandidatoController {
     }
 
     /**
-     * Atualiza os dados de um do curriculo de um candidato existente com base no ID informado.
-     *
-     * @param id o identificador único do candidato a ser atualizado (vindo da URL)
-     * @param requestDTO os dados do candidato enviados no corpo da requisição
-     * @return ResponseEntity com os dados atualizados do candidato e status 200 (OK)
-     */
-    @PutMapping("/{id}/curriculo")
-    public ResponseEntity<CandidatoResponseDTO> atualizarCurriculo(
-            @PathVariable Long id,
-            @RequestBody @Valid CandidatoRequestDTO requestDTO) {
-        CandidatoResponseDTO responseDTO = candidatoService.atualizaCurriculo(id, requestDTO);
-        return ResponseEntity.ok(responseDTO);
-    }
-
-    /**
      * Deleta o candidato por ID fornecido
      * @param id o identificador único do candidato a ser deletado
      * @return ResponseEntity com status 204 (No Content) se a exclusão for bem-sucedida

--- a/src/main/java/com/example/temosvagas/dtos/CandidatoRequestDTO.java
+++ b/src/main/java/com/example/temosvagas/dtos/CandidatoRequestDTO.java
@@ -54,6 +54,7 @@ public record CandidatoRequestDTO(
         candidato.setHabilidades(habilidades);
         candidato.setCurso(curso);
         candidato.setSemestreAtual(semestreAtual);
+        candidato.setArquivo("");
         return candidato;
     }
 }

--- a/src/main/java/com/example/temosvagas/services/CandidatoService.java
+++ b/src/main/java/com/example/temosvagas/services/CandidatoService.java
@@ -22,6 +22,7 @@ public class CandidatoService {
     @Autowired
     private PasswordEncoder passwordEncoder; // IMPORTANTE
 
+
     public List<CandidatoResponseDTO> buscaTodosCandidatos() {
         List<Candidato> candidatos = candidatoRepository.findAll();
         List<CandidatoResponseDTO> dtos = MapperGeral.toCandidatoResponseList(candidatos);
@@ -59,22 +60,6 @@ public class CandidatoService {
         candidato.setEmail(dto.email());
         candidato.setTelefone(dto.telefone());
         candidato.setCpf(dto.cpf());
-
-        Candidato candidatoSalvo = this.candidatoRepository.save(candidato);
-
-        return CandidatoResponseDTO.toDTO(candidatoSalvo);
-    }
-
-    public CandidatoResponseDTO atualizaCurriculo(Long id, CandidatoRequestDTO dto) {
-        Candidato candidato = candidatoRepository.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Candidato não encontrado"));
-
-        candidato.setCursandoGraduacao(dto.cursandoGraduacao());
-        candidato.setAnoConclusao(dto.anoConclusao());
-        candidato.setHabilidades(dto.habilidades());
-        candidato.setCurso(dto.curso());
-        candidato.setSemestreAtual(dto.semestreAtual());
-        candidato.setArquivo(dto.arquivo());
 
         Candidato candidatoSalvo = this.candidatoRepository.save(candidato);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,5 +9,8 @@ spring.datasource.password=ochamado
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
+aws.region=us-east-1
+aws.bucket.name=temos-vagas
+
 spring.jpa.properties.hibernate.jdbc.lab.non_contextual_creation=true
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
## feat(candidato): atualização de currículo com envio para S3

Este PR adiciona o endpoint `PUT /candidato/arquivo` para permitir que candidatos atualizem seus currículos.

### ✨ Funcionalidade
- Recebe requisição `multipart/form-data` com:
  - `id`: identificador do candidato
  - `arquivo`: novo currículo (arquivo PDF ou similar)
- Substitui o currículo anterior, armazenando o novo no bucket S3
- Retorna os dados atualizados do candidato com status **HTTP 200 (OK)**

### ✅ Objetivo
Permitir que o candidato atualize seu currículo de forma segura e eficiente, com armazenamento externo via Amazon S3.